### PR TITLE
Update download_models.sh with more robust URL. (#168)

### DIFF
--- a/download_models.sh
+++ b/download_models.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-wget https://www.dropbox.com/s/4j4z58wuv8o0mfz/models.zip
+wget https://dl.dropboxusercontent.com/s/4j4z58wuv8o0mfz/models.zip
 unzip models.zip


### PR DESCRIPTION
The old models.zip URL didn't work with certain .wgetrc settings. This new one seems to be more robust.

fixes #167